### PR TITLE
sigc++ cflags fix for sigc++ v.2.5.1+ (Ubuntu 16.04)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,10 @@ set(PROJECT_DESCRIPTION "Service discovery based on AVAHI")
 
 include(FindPkgConfig)
 pkg_check_modules(SIGC++ REQUIRED "sigc++-2.0")
+
 ## Using the quotation marks to get the ';' as field separator for string lists 
-list(APPEND MY_CFLAGS ${SIGC++_INCLUDE_DIRS})
-string(REGEX REPLACE ";" " -I" THIS_PKG_CFLAGS "${MY_CFLAGS}")
-message(${THIS_PKG_CFLAGS})
-set(THIS_PKG_CFLAGS "-I${THIS_PKG_CFLAGS}")
+list(APPEND MY_CFLAGS ${SIGC++_CFLAGS})
+string(REGEX REPLACE ";" " " THIS_PKG_CFLAGS "${MY_CFLAGS}")
 message(${THIS_PKG_CFLAGS})
 
 find_package(Boost REQUIRED COMPONENTS regex system)


### PR DESCRIPTION
Purpose of the PR:
Ubuntu 16.04 ships with sigc++ v.2.6.2 and
[libsigc++ version 2.5.1 and later require a compiler with C++11 support](http://libsigc.sourceforge.net/)

Currently service_discovery's pkg-config file does not include -std=c++11 cflag. This makes building of *drivers-orogen-transformer* and *tools-logger* to fail.

This PR uses cflags variable (SIGC++_CFLAGS) rather than just include directories (SIGC++_INCLUDE_DIRS) to configure service_discovery.pc.in. This way the flag -std=c++11 gets included into the resulting .pc file.



Tested on Ubuntu 16.04.