### PR TITLE
Add sigc++-2.0 to pkg-config Requires field, so that cflags are passe…

### DIFF
--- a/src/service_discovery.pc.in
+++ b/src/service_discovery.pc.in
@@ -7,4 +7,5 @@ Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
 Libs: -L${libdir} -l@PROJECT_NAME@ 
+Requires: sigc++-2.0
 Cflags: -I${includedir} -I${includedir}/service_discovery/backward @THIS_PKG_CFLAGS@


### PR DESCRIPTION
…d on

"libsigc++ version 2.5.1 and later require a compiler with C++11 support" which is the case e.g. for Ubuntu Xenial